### PR TITLE
Initialize admin log offsets during initial scan

### DIFF
--- a/src/main/adminLogWatcher.ts
+++ b/src/main/adminLogWatcher.ts
@@ -238,12 +238,16 @@ export async function startAdminLogWatcher(fileManager: FileManager) {
         const dateB = b.replace('admin_', '').replace('.log', '');
         return dateB.localeCompare(dateA);
       });
-      
+
       // Processar apenas o arquivo mais recente para determinar estado atual
       const mostRecentFile = adminLogs[0];
+      const offsets = await readOffsets();
       const logFile = path.join(logsPath, mostRecentFile);
       const stats = await fs.stat(logFile);
-      
+
+      offsets[mostRecentFile] = stats.size;
+      await writeOffsets(offsets);
+
       console.log(`[AdminLogWatcher] 🚀 Processando arquivo mais recente: ${mostRecentFile} (size: ${stats.size})`);
       
       const content = await fs.readFile(logFile, 'utf8');


### PR DESCRIPTION
## Summary
- load existing admin log offsets during the initial scan
- persist the most recent log's file size as the starting offset to avoid rereading on watcher events

## Testing
- npm run lint *(fails: existing lint violations in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cd932a67b08329a262dcdb0b2ac464